### PR TITLE
A small bug fixed for data saving

### DIFF
--- a/sample_script.py
+++ b/sample_script.py
@@ -101,6 +101,7 @@ class TroughDataHelper(object):
                 sampled by the trough at the same time"""
         with self._flock:
             for measurement in data:
+                measurement = list(measurement) # convert a tuple to a list before processing
                 measurement[mtx.uTTime] += self._time_offset
                 count = measurement[0]
                 if count > 0:


### PR DESCRIPTION
The measurement data retrieved from Kibron trough is a tuple. Converting it to a list is needed before further processing.